### PR TITLE
Adding additional cert constraints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,4 @@
-
--include .env
-
-#VERSION := $(shell git describe --tags)
-#BUILD := $(shell git rev-parse --short HEAD)
-PROJECTNAME := in-toto-go
-
-# Go related variables.
-#GOBASE := $(shell pwd)
-#GOPATH := $(GOBASE)/vendor:$(GOBASE)
-#GOBIN := $(GOBASE)/bin
-#GOFILES := $(wildcard *.go)
-
-# Use linker flags to provide version/build settings
-#LDFLAGS=-ldflags "-X=main.Version=$(VERSION) -X=main.Build=$(BUILD)"
-
-# Make is verbose in Linux. Make it silent.
-#MAKEFLAGS += --silent
-
-#Common Certificate Attributes
+# Common Certificate Attributes
 TRUST_DOMAIN_FQDN := example.com
 DEFAULT_BITS := 2048
 DEFAULT_MD := sha512
@@ -27,13 +8,13 @@ ROOT_DAYS := 3650
 INTERMEDIATE_DAYS := 3650
 LEAF_DAYS := 1
 
-#Template Location
+# Template Locations
 OPENSSL_TMPL := ./certs/openssl.cnf.tmpl
 LAYOUT_TMPL := ./certs/layout.tmpl
 
 build: modules
 	@mkdir -p bin
-	@go build -o=./bin/in-toto ./cmd/in-toto
+	@go build -o ./bin/in-toto ./cmd/in-toto
 
 modules:
 	@go mod tidy
@@ -42,34 +23,34 @@ clean: clean-certs clean-test-files
 	@rm -rf ./bin
 
 clean-certs:
-	@rm ./certs/*.pem ./certs/*.srl ./certs/*.cnf
+	@rm -rf ./certs/*.pem ./certs/*.srl ./certs/*.cnf
 
 clean-test-files:
 	@rm -rf ./test/tmp
-	@rm ./untar.link
+	@rm -rf ./untar.link
+	@rm -rf ./.srl
 
-generate_layout: leaf_certs
-	@mkdir -p ./test/tmp
-	$(eval rootid := $(shell ./bin/in-toto key id ./certs/root.cert.pem))
-	$(eval rootca := $(shell ./bin/in-toto key layout ./certs/root.cert.pem | sed -e 's/\\n/\\\\n/g'))
-	@cat $(LAYOUT_TMPL) | sed -e 's#{{ROOTCA}}#$(rootca)#' -e 's#{{ROOTID}}#$(rootid)#' > ./test/tmp/test.layout
+test: go-test test-verify
 
-test: go-test test-verify test-run
+go-test:
+	@go test ./...
 
 test-sign: build generate_layout
+	# Running test-sign
 	@./bin/in-toto sign -f ./test/tmp/test.layout -k ./certs/example.com.layout.key.pem -o ./test/tmp/signed.layout
 
-test-run: build
-	#Step 1
+test-run: build generate_layout
+	# Running write code step
 	@./bin/in-toto run -n write-code -c ./certs/example.com.write-code.cert.pem -k ./certs/example.com.write-code.key.pem -p ./test/tmp/foo.py -d ./test/tmp -- /bin/sh -c "echo hello > ./test/tmp/foo.py"
-	#Step 2
+	# Running package step
 	@./bin/in-toto run -n package -c ./certs/example.com.package.cert.pem -k ./certs/example.com.package.key.pem -m ./test/tmp/foo.py -p ./test/tmp/foo.tar.gz -d ./test/tmp -- tar zcvf ./test/tmp/foo.tar.gz ./test/tmp/foo.py
 
-test-verify: build test-sign test-run
+test-verify: test-sign test-run
+	# Running test verify
 	@./bin/in-toto verify -l ./test/tmp/signed.layout -k ./certs/example.com.layout.cert.pem -i ./certs/example.com.intermediate.cert.pem -d ./test/tmp
 
-
-
+test-spiffe-sign: build spiffe-test-generate-layout
+	@./bin/in-toto sign -f ./test/tmp/spiffe.test.layout -k ./test/tmp/layout-key.pem -o ./test/tmp/spiffe.signed.layout
 
 spiffe-test-generate-layout:
 	@mkdir -p ./test/tmp
@@ -80,40 +61,40 @@ spiffe-test-generate-layout:
 	$(eval rootca := $(shell  awk -v ORS='\\\\n' '1' ./test/tmp/layout-bundle.pem))
 	@cat $(LAYOUT_TMPL) | sed -e 's#{{ROOTCA}}#$(rootca)#' > ./test/tmp/spiffe.test.layout
 
-test-spiffe-sign: build spiffe-test-generate-layout
-	@./bin/in-toto sign -f ./test/tmp/spiffe.test.layout -k ./test/tmp/layout-key.pem -o ./test/tmp/spiffe.signed.layout
-
-
-
-
-
-go-test:
-	@go test ./...
-
-generate-test-certs: intermediate_cert
+generate_layout: leaf_certs
+	@mkdir -p ./test/tmp
+	$(eval rootid := $(shell ./bin/in-toto key id ./certs/root.cert.pem))
+	$(eval rootca := $(shell ./bin/in-toto key layout ./certs/root.cert.pem | sed -e 's/\\n/\\\\n/g'))
+	@cat $(LAYOUT_TMPL) | sed -e 's#{{ROOTCA}}#$(rootca)#' -e 's#{{ROOTID}}#$(rootid)#' > ./test/tmp/test.layout
 
 root-cert:
+	# Generate root cert openssl conf file
 	$(call generate_openssl_conf,root)
-	#Create Root Key
+
+	# Create Root Key
 	@openssl genrsa -out ./certs/root.key.pem
-	#Create Root Cert
+
+	# Create Root Cert
 	@openssl req -subj "/C=/ST=/L=/O=$(ORGANIZATION)/OU=$(ORGANIZATIONAL_UNIT)CN=root/" -days $(ROOT_DAYS) -x509 -new \
 	-key "./certs/root.key.pem" -out "./certs/root.cert.pem" \
 	-config ./certs/$(TRUST_DOMAIN_FQDN).root.openssl.cnf \
 	-extensions v3-root
 
-
 intermediate_cert: root-cert
+	# Generate intermediate cert openssl conf file
 	$(call generate_openssl_conf,intermediate)
-	#Create intermediate key
+
+	# Create intermediate key
 	@openssl genrsa -out ./certs/$(TRUST_DOMAIN_FQDN).intermediate.key.pem
-	#Generate intermediate CSR
+
+	# Generate intermediate CSR
 	@openssl req -subj "/C=/ST=/L=/O=$(ORGANIZATION)/OU=$(ORGANIZATIONAL_UNIT)CN=$(TRUST_DOMAIN_FQDN)" -new \
 	-key ./certs/$(TRUST_DOMAIN_FQDN).intermediate.key.pem \
 	-out ./certs/$(TRUST_DOMAIN_FQDN).intermediate.csr.pem \
 	-config ./certs/$(TRUST_DOMAIN_FQDN).intermediate.openssl.cnf \
 	-extensions v3-intermediate
-	#Sign Intermediate CSR Using Root Certificate
+
+	# Sign Intermediate CSR Using Root Certificate
 	@openssl x509 -days $(INTERMEDIATE_DAYS) -req \
 	-CAcreateserial \
 	-CA ./certs/root.cert.pem \
@@ -122,6 +103,8 @@ intermediate_cert: root-cert
 	-out ./certs/$(TRUST_DOMAIN_FQDN).intermediate.cert.pem \
 	-extfile ./certs/$(TRUST_DOMAIN_FQDN).intermediate.openssl.cnf \
 	-extensions v3-intermediate
+
+	# Verify intermediate cert was signed by root cert
 	@openssl verify -CAfile ./certs/root.cert.pem ./certs/$(TRUST_DOMAIN_FQDN).intermediate.cert.pem
 
 leaf_certs: intermediate_cert
@@ -129,17 +112,21 @@ leaf_certs: intermediate_cert
 	$(call generate_leaf_cert,write-code)
 	$(call generate_leaf_cert,package)
 
-define generate_leaf_cert	
+define generate_leaf_cert
+	# Generate leaf cert openssl conf file
 	$(call generate_openssl_conf,$(1))
-	#Generate leaf signing key
+
+	# Generate leaf signing key
 	@openssl genrsa -out ./certs/$(TRUST_DOMAIN_FQDN).$(1).key.pem
-	#Generate leaf CSR
+
+	# Generate leaf CSR
 	openssl req -new \
 	-key ./certs/$(TRUST_DOMAIN_FQDN).$(1).key.pem \
 	-out ./certs/$(TRUST_DOMAIN_FQDN).$(1).csr.pem \
 	-config ./certs/$(TRUST_DOMAIN_FQDN).$(1).openssl.cnf \
 	-extensions v3-leaf
-	#Sign leaf CSR Using intermediate Certificate
+
+	# Sign leaf CSR Using intermediate Certificate
 	@openssl x509 -days $(LEAF_DAYS) -req \
 	-CAcreateserial \
 	-CA ./certs/$(TRUST_DOMAIN_FQDN).intermediate.cert.pem \
@@ -148,6 +135,12 @@ define generate_leaf_cert
 	-out ./certs/$(TRUST_DOMAIN_FQDN).$(1).cert.pem \
 	-extfile ./certs/$(TRUST_DOMAIN_FQDN).$(1).openssl.cnf \
 	-extensions v3-leaf
+
+	# Create cert bundle for trust domain
+	cat ./certs/root.cert.pem ./certs/$(TRUST_DOMAIN_FQDN).intermediate.cert.pem > ./certs/$(TRUST_DOMAIN_FQDN).bundle.cert.pem
+
+	# Verify leaf cert chain
+	@openssl verify -CAfile ./certs/$(TRUST_DOMAIN_FQDN).bundle.cert.pem ./certs/$(TRUST_DOMAIN_FQDN).$(1).cert.pem
 endef
 
 define generate_openssl_conf
@@ -158,7 +151,6 @@ define generate_openssl_conf
 	sed -e 's/{{DEFAULT_MD}}/$(DEFAULT_MD)/' | \
 	sed -e 's/{{SPIFFE_PATH}}/$(1)/' > certs/$(TRUST_DOMAIN_FQDN).$(1).openssl.cnf
 endef
-
 
 .PHONY: help
 all: help

--- a/certs/layout.tmpl
+++ b/certs/layout.tmpl
@@ -54,8 +54,20 @@
     "cert_constraints": [
      {
       "common_name": "write-code.example.com",
+      "dns_names": [
+        ""
+      ],
+      "emails": [
+        ""
+      ],
+      "organizations": [
+        "*"
+      ],
+      "roots": [
+        "*"
+      ],
       "uris": [
-       "spiffe://example.com/write-code"
+        "spiffe://example.com/write-code"
       ]
      }
     ],
@@ -76,6 +88,18 @@
     "cert_constraints": [
      {
       "common_name": "package.example.com",
+      "dns_names": [
+       ""
+      ],
+      "emails": [
+       ""
+      ],
+      "organizations": [
+       "*"
+      ],
+      "roots": [
+       "*"
+      ],
       "uris": [
        "spiffe://example.com/package"
       ]

--- a/certs/openssl.cnf.tmpl
+++ b/certs/openssl.cnf.tmpl
@@ -17,7 +17,7 @@ basicConstraints=critical,CA:TRUE
 keyUsage=critical,keyCertSign,cRLSign
 subjectAltName=URI:spiffe://root
 
-[ v3-intermediate ]
+[v3-intermediate]
 subjectKeyIdentifier=hash
 authorityKeyIdentifier=keyid:always,issuer:always
 basicConstraints=critical,CA:TRUE
@@ -25,7 +25,7 @@ keyUsage=critical,keyCertSign,cRLSign
 subjectAltName=URI:spiffe://{{TRUST_DOMAIN_FQDN}}
 
 
-[ v3-leaf ]
+[v3-leaf]
 subjectAltName=critical,URI:spiffe://{{TRUST_DOMAIN_FQDN}}/{{SPIFFE_PATH}}
 keyUsage = critical,digitalSignature,keyEncipherment,nonRepudiation
 basicConstraints = CA:false

--- a/in_toto/certconstraint.go
+++ b/in_toto/certconstraint.go
@@ -2,6 +2,7 @@ package in_toto
 
 import (
 	"crypto/x509"
+	"fmt"
 	"net/url"
 )
 
@@ -14,18 +15,94 @@ const (
 // asserts that the certificate must have nothing for that attribute. A certificate must have
 // every value defined in a constraint to match.
 type CertificateConstraint struct {
-	CommonName string   `json:"common_name"`
-	URIs       []string `json:"uris"`
+	CommonName    string   `json:"common_name"`
+	DNSNames      []string `json:"dns_names"`
+	Emails        []string `json:"emails"`
+	Organizations []string `json:"organizations"`
+	Roots         []string `json:"roots"`
+	URIs          []string `json:"uris"`
 }
 
-// Check tests the provided certificate against the constraint. True is returned if the certificate
-// satisifies the constraint, false will be returned otherwise.
-func (cc CertificateConstraint) Check(cert *x509.Certificate) bool {
-	if cc.CommonName != AllowAllConstraint && cc.CommonName != cert.Subject.CommonName {
-		return false
-	}
+// checkResult is a data structure used to hold
+// certificate constraint errors
+type checkResult struct {
+	errors []error
+}
 
-	return checkConstraintAttribute(cc.URIs, urisToStrings(cert.URIs))
+// newCheckResult initializes a new checkResult
+func newCheckResult() *checkResult {
+	return &checkResult{
+		errors: make([]error, 0),
+	}
+}
+
+// evaluate runs a constraint check on a certificate
+func (cr *checkResult) evaluate(cert *x509.Certificate, constraintCheck func(*x509.Certificate) error) *checkResult {
+	err := constraintCheck(cert)
+	if err != nil {
+		cr.errors = append(cr.errors, err)
+	}
+	return cr
+}
+
+// error reduces all of the errors into one error with a
+// combined error message. If there are no errors, nil
+// will be returned.
+func (cr *checkResult) error() error {
+	if len(cr.errors) == 0 {
+		return nil
+	}
+	return fmt.Errorf("cert failed constraints check: %+q", cr.errors)
+}
+
+// Check tests the provided certificate against the constraint. An error is returned if the certificate
+// fails any of the constraints. nil is returned if the certificate passes all of the constraints.
+func (cc CertificateConstraint) Check(cert *x509.Certificate, rootCAIDs []string, rootCertPool, intermediateCertPool *x509.CertPool) error {
+	return newCheckResult().
+		evaluate(cert, cc.checkCommonName).
+		evaluate(cert, cc.checkDNSNames).
+		evaluate(cert, cc.checkEmails).
+		evaluate(cert, cc.checkOrganizations).
+		evaluate(cert, cc.checkRoots(rootCAIDs, rootCertPool, intermediateCertPool)).
+		evaluate(cert, cc.checkURIs).
+		error()
+}
+
+// checkCommonName verifies that the certificate's common name matches the constraint.
+func (cc CertificateConstraint) checkCommonName(cert *x509.Certificate) error {
+	return checkCertConstraint("common name", []string{cc.CommonName}, []string{cert.Subject.CommonName})
+}
+
+// checkDNSNames verifies that the certificate's dns names matches the constraint.
+func (cc CertificateConstraint) checkDNSNames(cert *x509.Certificate) error {
+	return checkCertConstraint("dns name", cc.DNSNames, cert.DNSNames)
+}
+
+// checkEmails verifies that the certificate's emails matches the constraint.
+func (cc CertificateConstraint) checkEmails(cert *x509.Certificate) error {
+	return checkCertConstraint("email", cc.Emails, cert.EmailAddresses)
+}
+
+// checkOrganizations verifies that the certificate's organizations matches the constraint.
+func (cc CertificateConstraint) checkOrganizations(cert *x509.Certificate) error {
+	return checkCertConstraint("organization", cc.Organizations, cert.Subject.Organization)
+}
+
+// checkRoots verifies that the certificate's roots matches the constraint.
+// The certificates trust chain must also be verified.
+func (cc CertificateConstraint) checkRoots(rootCAIDs []string, rootCertPool, intermediateCertPool *x509.CertPool) func(*x509.Certificate) error {
+	return func(cert *x509.Certificate) error {
+		_, err := VerifyCertificateTrust(cert, rootCertPool, intermediateCertPool)
+		if err != nil {
+			return fmt.Errorf("failed to verify roots: %w", err)
+		}
+		return checkCertConstraint("root", cc.Roots, rootCAIDs)
+	}
+}
+
+// checkURIs verifies that the certificate's URIs matches the constraint.
+func (cc CertificateConstraint) checkURIs(cert *x509.Certificate) error {
+	return checkCertConstraint("uri", cc.URIs, urisToStrings(cert.URIs))
 }
 
 // urisToStrings is a helper that converts a list of URL objects to the string that represents them
@@ -38,24 +115,42 @@ func urisToStrings(uris []*url.URL) []string {
 	return res
 }
 
-// checkConstraintAttribute tests that the provided test values match the allowed values of the constraint.
+// checkCertConstraint tests that the provided test values match the allowed values of the constraint.
 // All allowed values must be met one-to-one to be considered a successful match.
-func checkConstraintAttribute(allowed, test []string) bool {
-	if len(allowed) == 1 && allowed[0] == AllowAllConstraint {
-		return true
+func checkCertConstraint(attributeName string, constraints, values []string) error {
+	// If the only constraint is to allow all and there is at least one value, then the check succeeds
+	if len(constraints) == 1 && constraints[0] == AllowAllConstraint && len(values) > 0 {
+		return nil
 	}
 
-	unmet := NewSet(allowed...)
-	for _, t := range test {
-		// if our test has a value we didn't expect, fail early
-		if !unmet.Has(t) {
-			return false
+	if len(constraints) == 1 && constraints[0] == "" {
+		constraints = []string{}
+	}
+
+	if len(values) == 1 && values[0] == "" {
+		values = []string{}
+	}
+
+	// If no constraints are specified, but the certificate has values for the attribute, then the check fails
+	if len(constraints) == 0 && len(values) > 0 {
+		return fmt.Errorf("not expecting any %s(s), but cert has %d %s(s)", attributeName, len(values), attributeName)
+	}
+
+	unmet := NewSet(constraints...)
+	for _, v := range values {
+		// if the cert has a value we didn't expect, fail early
+		if !unmet.Has(v) {
+			return fmt.Errorf("cert has an unexpected %s %s given constraints %+q", attributeName, v, constraints)
 		}
 
 		// consider the constraint met
-		unmet.Remove(t)
+		unmet.Remove(v)
 	}
 
 	// if we have any unmet left after going through each test value, fail.
-	return len(unmet) == 0
+	if len(unmet) > 0 {
+		return fmt.Errorf("cert with %s(s) %+q did not pass all constraints %+q", attributeName, values, constraints)
+	}
+
+	return nil
 }

--- a/in_toto/certconstraint_test.go
+++ b/in_toto/certconstraint_test.go
@@ -1,147 +1,479 @@
 package in_toto
 
 import (
+	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net/url"
 	"testing"
+	"time"
 )
 
-func TestCheckConstraintAttribute(t *testing.T) {
-	cases := []struct {
-		Allowed  []string
-		Test     []string
-		Expected bool
-	}{
+type checkConstraintAttributeCase struct {
+	Constraints []string
+	Values      []string
+	Expected    bool
+}
+
+func TestCheckCertConstraint(t *testing.T) {
+	cases := []checkConstraintAttributeCase{
 		{
-			Allowed:  []string{"test1", "test2"},
-			Test:     []string{"test2", "test1"},
-			Expected: true,
-		}, {
-			Allowed:  []string{"test1", "test2"},
-			Test:     []string{"test2"},
-			Expected: false,
-		}, {
-			Allowed:  []string{AllowAllConstraint},
-			Test:     []string{"any", "thing", "goes"},
-			Expected: true,
-		}, {
-			Allowed:  []string{},
-			Test:     []string{},
-			Expected: true,
-		}, {
-			Allowed:  []string{},
-			Test:     []string{"test1"},
-			Expected: false,
-		}, {
-			Allowed:  []string{"test1", "test2"},
-			Test:     []string{"test1", "test2", "test3"},
-			Expected: false,
+			Constraints: []string{"test1", "test2"},
+			Values:      []string{"test2", "test1"},
+			Expected:    true,
+		},
+		{
+			Constraints: []string{"test1", "test2"},
+			Values:      []string{"test2"},
+			Expected:    false,
+		},
+		{
+			Constraints: []string{AllowAllConstraint},
+			Values:      []string{"any", "thing", "goes"},
+			Expected:    true,
+		},
+		{
+			Constraints: []string{},
+			Values:      []string{},
+			Expected:    true,
+		},
+		{
+			Constraints: []string{},
+			Values:      []string{"test1"},
+			Expected:    false,
+		},
+		{
+			Constraints: []string{""},
+			Values:      []string{""},
+			Expected:    true,
+		},
+		{
+			Constraints: []string{""},
+			Values:      []string{"test1"},
+			Expected:    false,
+		},
+		{
+			Constraints: []string{"test1", "test2"},
+			Values:      []string{"test1", "test2", "test3"},
+			Expected:    false,
 		},
 	}
 
 	for _, c := range cases {
-		actual := checkConstraintAttribute(c.Allowed, c.Test)
+		err := checkCertConstraint("constraint", c.Constraints, c.Values)
+		actual := err == nil
 		if actual != c.Expected {
-			t.Errorf("Got %v when expected %v. Allowed: %v, Test: %v", actual, c.Expected, c.Allowed, c.Test)
+			t.Errorf("Got %v when expected %v. Constraints: %v, Values: %v", actual, c.Expected, c.Constraints, c.Values)
 		}
 	}
 }
 
-func TestConstraintCheck(t *testing.T) {
-	// this cert has a CN of step1.example.com, and a URI of spiffe://example.com/step1
-	testCertPem, _ := pem.Decode([]byte(`-----BEGIN CERTIFICATE-----
-MIIDRzCCAi+gAwIBAgIUExxFTHRndhbwwBlFSaItPQbhYSMwDQYJKoZIhvcNAQEL
-BQAwMjEQMA4GA1UECgwHZXhhbXBsZTEeMBwGA1UECwwVZXhhbXBsZUNOPWV4YW1w
-bGUuY29tMB4XDTIxMDEyODAxMjk0NVoXDTIxMDEyOTAxMjk0NVowQDEaMBgGA1UE
-AwwRc3RlcDEuZXhhbXBsZS5jb20xEDAOBgNVBAsMB2V4YW1wbGUxEDAOBgNVBAoM
-B2V4YW1wbGUwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDY6FZ2if5B
-5LeQRAFMMM3S1tdAP7eKiLiMj7Zlsey4EGorNrRP6Pscqgmg6DLaGg24AafEfgP0
-JQ7w4HtaHESk8SRr+C0lgvJxalMKoh0B99sXBulTnsPnjo4gLOVjEyPDbSoyjeyQ
-8tkjtkFtMIb3gzE8WbPzWOrux6ME3Yat96Dp+y0n8fXhm+EIcnQqy/tyHQSVnDJy
-5nYXDAcDYGwjM1klYaUZDSJUbhDy3aRTFdNnMhVdTcQWGZfh/rHmNzi2X+BSBnBH
-tc4nGd1gw23iPtGQxcLzGQngtBVmMPs/lACkrHWkYZ4AQg5wKBtPvSKazOhd7vsy
-cwHBSDMHcqZbAgMBAAGjRzBFMCgGA1UdEQEB/wQeMByGGnNwaWZmZTovL2V4YW1w
-bGUuY29tL3N0ZXAxMA4GA1UdDwEB/wQEAwIF4DAJBgNVHRMEAjAAMA0GCSqGSIb3
-DQEBCwUAA4IBAQCJOoVzTavmbhC6VmwwOvwTZffpTO1AJImB0E1Yia62AQ4Z9G4c
-X1tmiSqIYuKzmZzXl3cvwFsA3Za2Kv3DPjasgd1ge7tkeiBtAh+yZbRyCHtFw9kJ
-zMMz+wN5pnWb9e69gVkxyXc9FhzM4DNMLeupcRivxpo650N+LzRnEY/UKHyQgnyK
-Bh47mx/lMz81znHjW2MucWtym6qJAdYOw1VL+5gq1jfrl8azIvgOiaPGf7rRGYCA
-QYXYItG+6fK1B/xS14Hx7pqoG7MtOR3bsljygfsNIlw5NKjX+EIQDl1CzLtNw1NH
-yORP9/XlC7SjBgRsX0Jy2p1OXRiu4tvCottJ
------END CERTIFICATE-----`))
+type constraintCheckCase struct {
+	Constraint CertificateConstraint
+	Cert       *x509.Certificate
+	Expected   bool
+}
 
-	testCert, err := x509.ParseCertificate(testCertPem.Bytes)
-	if err != nil {
-		t.Fatalf("Failed to parse certificate from pem bytes: %v", err)
+func TestConstraintCheck(t *testing.T) {
+	testCertSubject := pkix.Name{
+		CommonName:   "step1.example.com",
+		Organization: []string{"example"},
+	}
+	testCertEmails := []string{"example@example.com"}
+	testCertDNSNames := []string{"example.com"}
+	testCertURI, _ := url.Parse("spiffe://example.com/step1")
+	testCertURIs := []*url.URL{testCertURI}
+	testertValidity := 1 * time.Hour
+	testCertPublicKeyAlgorithm := x509.Ed25519
+	testCertTemplate := &x509.Certificate{
+		Subject:        testCertSubject,
+		EmailAddresses: testCertEmails,
+		DNSNames:       testCertDNSNames,
+		URIs:           testCertURIs,
 	}
 
-	cases := []struct {
-		Constraint CertificateConstraint
-		Cert       *x509.Certificate
-		Expected   bool
-	}{{
-		Cert: testCert,
-		Constraint: CertificateConstraint{
-			CommonName: "step1.example.com",
-			URIs:       []string{"spiffe://example.com/step1"},
+	testCert, testIntermediateCert, testRootCert, err := createTestCert(testCertTemplate, testCertPublicKeyAlgorithm, testertValidity)
+	if err != nil {
+		t.Fatalf("failed to create test cert: %v", err)
+	}
+
+	rootCertPool := x509.NewCertPool()
+	rootCertPool.AddCert(testRootCert)
+	intermediateCertPool := x509.NewCertPool()
+	intermediateCertPool.AddCert(testIntermediateCert)
+
+	roots := []string{"example"}
+
+	cases := []constraintCheckCase{
+		{
+			Cert: testCert,
+			Constraint: CertificateConstraint{
+				CommonName:    "step1.example.com",
+				DNSNames:      []string{"example.com"},
+				Emails:        []string{"example@example.com"},
+				Organizations: []string{"example"},
+				Roots:         []string{"example"},
+				URIs:          []string{"spiffe://example.com/step1"},
+			},
+			Expected: true,
 		},
-		Expected: true,
-	}, {
-		Cert: testCert,
-		Constraint: CertificateConstraint{
-			CommonName: "*",
-			URIs:       []string{"spiffe://example.com/step1"},
+		{
+			Cert: testCert,
+			Constraint: CertificateConstraint{
+				CommonName:    "*",
+				DNSNames:      []string{"*"},
+				Emails:        []string{"*"},
+				Organizations: []string{"*"},
+				Roots:         []string{"*"},
+				URIs:          []string{"*"},
+			},
+			Expected: true,
 		},
-		Expected: true,
-	}, {
-		Cert: testCert,
-		Constraint: CertificateConstraint{
-			CommonName: "step1.example.com",
-			URIs:       []string{"*"},
+		{
+			Cert: testCert,
+			Constraint: CertificateConstraint{
+				CommonName:    "",
+				DNSNames:      []string{},
+				Emails:        []string{},
+				Organizations: []string{},
+				Roots:         []string{},
+				URIs:          []string{},
+			},
+			Expected: false,
 		},
-		Expected: true,
-	}, {
-		Cert: testCert,
-		Constraint: CertificateConstraint{
-			CommonName: "",
-			URIs:       []string{"*"},
+		{
+			Cert: testCert,
+			Constraint: CertificateConstraint{
+				CommonName:    "",
+				DNSNames:      []string{""},
+				Emails:        []string{""},
+				Organizations: []string{""},
+				Roots:         []string{""},
+				URIs:          []string{""},
+			},
+			Expected: false,
 		},
-		Expected: false,
-	}, {
-		Cert: testCert,
-		Constraint: CertificateConstraint{
-			CommonName: "step1.example.com",
-			URIs:       []string{""},
+		{
+			Cert: testCert,
+			Constraint: CertificateConstraint{
+				CommonName:    "",
+				DNSNames:      []string{"example.com"},
+				Emails:        []string{"example@example.com"},
+				Organizations: []string{"example"},
+				Roots:         []string{"example"},
+				URIs:          []string{"spiffe://example.com/step1"},
+			},
+			Expected: false,
 		},
-		Expected: false,
-	}, {
-		Cert: testCert,
-		Constraint: CertificateConstraint{
-			CommonName: "step1.example.com",
-			URIs:       []string{"spiffe://example.com/step1", "step1.example.com"},
+		{
+			Cert: testCert,
+			Constraint: CertificateConstraint{
+				CommonName:    "step1.example.com",
+				DNSNames:      []string{},
+				Emails:        []string{"example@example.com"},
+				Organizations: []string{"example"},
+				Roots:         []string{"example"},
+				URIs:          []string{"spiffe://example.com/step1"},
+			},
+			Expected: false,
 		},
-		Expected: false,
-	}, {
-		Cert: testCert,
-		Constraint: CertificateConstraint{
-			CommonName: "step1.example.com",
-			URIs:       []string{},
+		{
+			Cert: testCert,
+			Constraint: CertificateConstraint{
+				CommonName:    "step1.example.com",
+				DNSNames:      []string{"example.com"},
+				Emails:        []string{},
+				Organizations: []string{"example"},
+				Roots:         []string{"example"},
+				URIs:          []string{"spiffe://example.com/step1"},
+			},
+			Expected: false,
 		},
-		Expected: false,
-	}, {
-		Cert: testCert,
-		Constraint: CertificateConstraint{
-			CommonName: "",
-			URIs:       []string{},
+		{
+			Cert: testCert,
+			Constraint: CertificateConstraint{
+				CommonName:    "step1.example.com",
+				DNSNames:      []string{"example.com"},
+				Emails:        []string{"example@example.com"},
+				Organizations: []string{},
+				Roots:         []string{"example"},
+				URIs:          []string{"spiffe://example.com/step1"},
+			},
+			Expected: false,
 		},
-		Expected: false,
-	},
+		{
+			Cert: testCert,
+			Constraint: CertificateConstraint{
+				CommonName:    "step1.example.com",
+				DNSNames:      []string{"example.com"},
+				Emails:        []string{"example@example.com"},
+				Organizations: []string{"example"},
+				Roots:         []string{},
+				URIs:          []string{"spiffe://example.com/step1"},
+			},
+			Expected: false,
+		},
+		{
+			Cert: testCert,
+			Constraint: CertificateConstraint{
+				CommonName:    "*",
+				DNSNames:      []string{"*"},
+				Emails:        []string{"*"},
+				Organizations: []string{"*"},
+				Roots:         []string{"example2"},
+				URIs:          []string{"*"},
+			},
+			Expected: false,
+		},
+		{
+			Cert: testCert,
+			Constraint: CertificateConstraint{
+				CommonName:    "step1.example.com",
+				DNSNames:      []string{"example.com"},
+				Emails:        []string{"example@example.com"},
+				Organizations: []string{"example"},
+				Roots:         []string{"example"},
+				URIs:          []string{},
+			},
+			Expected: false,
+		},
+		{
+			Cert: testCert,
+			Constraint: CertificateConstraint{
+				CommonName:    "*",
+				DNSNames:      []string{"*"},
+				Emails:        []string{"*"},
+				Organizations: []string{"*"},
+				Roots:         []string{"*"},
+				URIs:          []string{"spiffe://example.com/step1", "step1.example.com"},
+			},
+			Expected: false,
+		},
+		{
+			Cert: testCert,
+			Constraint: CertificateConstraint{
+				CommonName:    "*",
+				DNSNames:      []string{"*"},
+				Emails:        []string{"*"},
+				Organizations: []string{"*"},
+				Roots:         []string{"*"},
+				URIs:          []string{"spiffe://example.com/step2"},
+			},
+			Expected: false,
+		},
 	}
 
 	for _, c := range cases {
-		actual := c.Constraint.Check(c.Cert)
+		err := c.Constraint.Check(c.Cert, roots, rootCertPool, intermediateCertPool)
+		actual := err == nil
 		if actual != c.Expected {
-			t.Errorf("Got %v when expected %v. Constraint: %v, Certificate: %v", actual, c.Expected, c.Constraint, c.Cert)
+			t.Errorf("Got %v when expected %v. Constraint: %+v, Errors: %s", actual, c.Expected, c.Constraint, err)
 		}
 	}
+}
+
+func createTestCert(template *x509.Certificate, publicKeyAlgorithm x509.PublicKeyAlgorithm, validity time.Duration) (*x509.Certificate, *x509.Certificate, *x509.Certificate, error) {
+	rootCertSubject := pkix.Name{
+		CommonName: "Root CA",
+	}
+	rootCertMaxPathLen := 1
+	rootCertValidity := 10 * 365 * 24 * time.Hour // 10 years
+	rootCertPublicKeyAlgorithm := x509.Ed25519
+	rootCertTemplate := &x509.Certificate{
+		Subject:    rootCertSubject,
+		MaxPathLen: rootCertMaxPathLen,
+	}
+	rootCert, _, rootKey, err := createSelfSignedCA(rootCertTemplate, rootCertPublicKeyAlgorithm, rootCertValidity)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	intermediateCertSubject := pkix.Name{
+		CommonName: "Intermediate CA",
+	}
+	intermediateCertMaxPathLen := 0
+	intermediateCertValidity := 10 * 365 * 24 * time.Hour
+	intermediateCertPublicKeyAlgorithm := x509.Ed25519
+	intermediateCertTemplate := &x509.Certificate{
+		Subject:    intermediateCertSubject,
+		MaxPathLen: intermediateCertMaxPathLen,
+	}
+	intermediateCert, _, intermediateKey, err := createCA(intermediateCertTemplate, rootCert, rootKey, intermediateCertPublicKeyAlgorithm, intermediateCertValidity)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	endEntityCert, _, _, err := createEndEntityCert(template, intermediateCert, intermediateKey, publicKeyAlgorithm, validity)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return endEntityCert, intermediateCert, rootCert, nil
+}
+
+func createSelfSignedCA(template *x509.Certificate, publicKeyAlgorithm x509.PublicKeyAlgorithm, validity time.Duration) (*x509.Certificate, []byte, crypto.PrivateKey, error) {
+	if template.Subject.CommonName == "" {
+		return nil, nil, nil, fmt.Errorf("subject common name must be set")
+	}
+
+	if template.MaxPathLen <= 0 {
+		return nil, nil, nil, fmt.Errorf("maxPathLen must be set and greater than 0")
+	}
+
+	serialNumber, err := createSerialNumber()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create certificate serial number: %w", err)
+	}
+
+	template.SerialNumber = serialNumber
+	template.NotBefore = time.Now()
+	template.NotAfter = time.Now().Add(validity)
+	template.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature
+	template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth}
+	template.BasicConstraintsValid = true
+	template.IsCA = true
+	template.MaxPathLenZero = false
+
+	publicKey, privateKey, err := createKeyPair(publicKeyAlgorithm)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create key pair: %w", err)
+	}
+
+	cert, certPEM, err := createCert(template, template, publicKey, privateKey)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create cert: %w", err)
+	}
+
+	return cert, certPEM, privateKey, nil
+}
+
+func createCA(template, issuerCert *x509.Certificate, issuerPrivateKey crypto.PrivateKey, publicKeyAlgorithm x509.PublicKeyAlgorithm, validity time.Duration) (*x509.Certificate, []byte, crypto.PrivateKey, error) {
+	if template.Subject.CommonName == "" {
+		return nil, nil, nil, fmt.Errorf("subject common name must be set")
+	}
+
+	serialNumber, err := createSerialNumber()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create certificate serial number: %w", err)
+	}
+
+	var maxPathLenZero bool
+	if template.MaxPathLen > 0 {
+		maxPathLenZero = false
+	} else {
+		maxPathLenZero = true
+	}
+
+	template.SerialNumber = serialNumber
+	template.NotBefore = time.Now()
+	template.NotAfter = time.Now().Add(validity)
+	template.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature
+	template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth}
+	template.BasicConstraintsValid = true
+	template.IsCA = true
+	template.MaxPathLenZero = maxPathLenZero
+
+	publicKey, privateKey, err := createKeyPair(publicKeyAlgorithm)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create key pair: %w", err)
+	}
+
+	cert, certPEM, err := createCert(template, issuerCert, publicKey, issuerPrivateKey)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create cert: %w", err)
+	}
+
+	return cert, certPEM, privateKey, nil
+}
+
+func createEndEntityCert(template, issuerCert *x509.Certificate, issuerPrivateKey crypto.PrivateKey, publicKeyAlgorithm x509.PublicKeyAlgorithm, validity time.Duration) (*x509.Certificate, []byte, crypto.PrivateKey, error) {
+	if template.Subject.CommonName == "" {
+		return nil, nil, nil, fmt.Errorf("subject common name must be set")
+	}
+
+	serialNumber, err := createSerialNumber()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create certificate serial number: %w", err)
+	}
+
+	template.SerialNumber = serialNumber
+	template.NotBefore = time.Now()
+	template.NotAfter = time.Now().Add(validity)
+	template.KeyUsage = x509.KeyUsageDigitalSignature
+	template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth}
+	template.IsCA = false
+	template.MaxPathLenZero = true
+
+	publicKey, privateKey, err := createKeyPair(publicKeyAlgorithm)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create key pair: %w", err)
+	}
+
+	cert, certPEM, err := createCert(template, issuerCert, publicKey, issuerPrivateKey)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create cert: %w", err)
+	}
+
+	return cert, certPEM, privateKey, nil
+}
+
+func createKeyPair(publicKeyAlgorithm x509.PublicKeyAlgorithm) (crypto.PublicKey, crypto.PrivateKey, error) {
+	var publicKey crypto.PublicKey
+	var privateKey crypto.PrivateKey
+
+	switch publicKeyAlgorithm {
+
+	case x509.RSA:
+		rsaPrivateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to generate rsa private key: %w", err)
+		}
+		publicKey = &rsaPrivateKey.PublicKey
+		privateKey = rsaPrivateKey
+
+	case x509.Ed25519:
+		ed25519PublicKey, ed25519PrivateKey, err := ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to generate ed25519 key pair: %w", err)
+		}
+		publicKey = ed25519PublicKey
+		privateKey = ed25519PrivateKey
+
+	default:
+		return nil, nil, fmt.Errorf("unsupported public key algorithm")
+	}
+
+	return publicKey, privateKey, nil
+}
+
+func createCert(template, issuer *x509.Certificate, subjectPublicKey crypto.PublicKey, issuerPrivateKey crypto.PrivateKey) (*x509.Certificate, []byte, error) {
+	certBytes, err := x509.CreateCertificate(rand.Reader, template, issuer, subjectPublicKey, issuerPrivateKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create certificate: %w", err)
+	}
+
+	cert, err := x509.ParseCertificate(certBytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse certificate: %w", err)
+	}
+
+	b := pem.Block{Type: "CERTIFICATE", Bytes: certBytes}
+	certPEM := pem.EncodeToMemory(&b)
+
+	return cert, certPEM, err
+}
+
+func createSerialNumber() (*big.Int, error) {
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 256)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate serial number: %w", err)
+	}
+	return serialNumber, nil
 }

--- a/in_toto/runlib.go
+++ b/in_toto/runlib.go
@@ -287,19 +287,16 @@ func InTotoRun(name string, runDir string, materialPaths []string, productPaths 
 
 	materials, err := RecordArtifacts(materialPaths, hashAlgorithms, gitignorePatterns, lStripPaths)
 	if err != nil {
-		fmt.Println(err)
 		return linkMb, err
 	}
 
 	byProducts, err := RunCommand(cmdArgs, runDir)
 	if err != nil {
-		fmt.Println(err)
 		return linkMb, err
 	}
 
 	products, err := RecordArtifacts(productPaths, hashAlgorithms, gitignorePatterns, lStripPaths)
 	if err != nil {
-		fmt.Println(err)
 		return linkMb, err
 	}
 
@@ -320,7 +317,6 @@ func InTotoRun(name string, runDir string, materialPaths []string, productPaths 
 	// with other values than the default ones.
 	if !reflect.ValueOf(key).IsZero() {
 		if err := linkMb.Sign(key); err != nil {
-			fmt.Println(err)
 			return linkMb, err
 		}
 	}

--- a/in_toto/verifylib.go
+++ b/in_toto/verifylib.go
@@ -528,12 +528,7 @@ func VerifyLinkSignatureThesholds(layout Layout,
 				}
 
 				// test certificate against the step's constraints to make sure it's a valid functionary
-				if !step.CheckCertConstraints(cert) {
-					continue
-				}
-
-				// test against the root pool with the key's certificate if it has any
-				if err := VerifyCertificateTrust(cert, rootCertPool, intermediateCertPool); err != nil {
+				if !step.CheckCertConstraints(cert, layout.RootCAIDs(), rootCertPool, intermediateCertPool) {
 					continue
 				}
 

--- a/in_toto/verifylib_test.go
+++ b/in_toto/verifylib_test.go
@@ -824,7 +824,6 @@ func TestInTotoVerifyWithDirectory(t *testing.T) {
 	}
 
 	// No error should occur
-	// TODO Brian fix this
 	if _, err := InTotoVerifyWithDirectory(layoutMb, layouKeys, linkDir, ".", "",
 		make(map[string]string), [][]byte{}); err != nil {
 		t.Error(err)


### PR DESCRIPTION
Adding additional cert constraints to limit who can act as a valid functionary for each step

Certs can now be constrained by:
* Common Name
* Organization
* DNS Name
* Email
* URI
* Root Key ID

Signed-off-by: Brian Dunnigan <brian@boxboat.com>

*Please fill in the fields below to submit a pull request.  The more
information that is provided, the better.*

**Fixes issue #48:


**Description of pull request**:


**Please verify and check that the pull request fulfills the following
requirements**:

- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


